### PR TITLE
URL Cleanup

### DIFF
--- a/org.springframework.flex.roo.addon/pom.xml
+++ b/org.springframework.flex.roo.addon/pom.xml
@@ -31,32 +31,32 @@
 		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.external</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/external</url>
+			<url>https://repository.springsource.com/maven/bundles/external</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.milestone</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Milestones</name>
-			<url>http://repository.springsource.com/maven/bundles/milestone</url>
+			<url>https://repository.springsource.com/maven/bundles/milestone</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.snapshot</id>
 			<name>SpringSource Enterprise Bundle Repository - Nightly Snapshots</name>
-			<url> http://repository.springsource.com/maven/bundles/snapshot</url>
+			<url> https://repository.springsource.com/maven/bundles/snapshot</url>
 		</repository>
 		<repository>
 			<id>maven.springframework.org.milestone</id>
 			<name>Spring Framework Maven Repository - Milestone Releases</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>maven.springframework.org.snapshot</id>
 			<name>Spring Framework Maven Repository - Nightly Snapshots</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>metaas-repo</id>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://maven.badgers-in-foil.co.uk/maven2/ (403) migrated to:  
  http://maven.badgers-in-foil.co.uk/maven2/ ([https](https://maven.badgers-in-foil.co.uk/maven2/) result AnnotatedConnectException).
* http://spring-roo-repository.springsource.org/release (404) migrated to:  
  http://spring-roo-repository.springsource.org/release ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://repository.springsource.com/maven/bundles/external (404) migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/milestone (404) migrated to:  
  https://repository.springsource.com/maven/bundles/milestone ([https](https://repository.springsource.com/maven/bundles/milestone) result 404).
* http://repository.springsource.com/maven/bundles/release (404) migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).
* http://repository.springsource.com/maven/bundles/snapshot (404) migrated to:  
  https://repository.springsource.com/maven/bundles/snapshot ([https](https://repository.springsource.com/maven/bundles/snapshot) result 404).

## Fixed Success 
These URLs were fixed successfully.

* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance