### PR TITLE
URL Cleanup

### DIFF
--- a/docbkx/flexaddon.xml
+++ b/docbkx/flexaddon.xml
@@ -7,14 +7,14 @@
             Spring Roo brings brings a whole new level of productivity to building Java applications.  From the Spring Roo Reference Guide:
         </para>
         <para>
-            "<ulink url="http://www.springsource.org/roo">Spring Roo</ulink> is an easy-to-use productivity tool for rapidly building enterprise applications in the 
+            "<ulink url="https://www.springsource.org/roo">Spring Roo</ulink> is an easy-to-use productivity tool for rapidly building enterprise applications in the 
             Java programming language. It allows you to build high-quality, high-performance, lock-in-free enterprise applications in just minutes. Best of all, Roo 
             works alongside your existing Java knowledge, skills and experience. You probably won't need to learn anything new to use Roo, as there's no new language 
             or runtime platform needed. You simply program in your normal Java way and Roo just works, sitting in the background taking care of the things you don't 
             want to worry about."
         </para>
         <para>
-            To learn more about Spring Roo itself, you'll find numerous resources from the project's homepage at <ulink url="http://www.springsource.org/roo">http://www.springsource.org/roo</ulink>
+            To learn more about Spring Roo itself, you'll find numerous resources from the project's homepage at <ulink url="https://www.springsource.org/roo">https://www.springsource.org/roo</ulink>
         </para>
         <para>
             The Flex Addon for Spring Roo aims to raise the bar for developer productivity in building Spring-based RIAs with a Flex client by meeting the 
@@ -47,14 +47,14 @@
             <title>Installing the Flex Addon for Spring Roo</title>
             <para>
                 The currently released version of the Flex Addon for Spring Roo is 1.0.0.M1.  The addon was included in the Spring BlazeDS Integration 1.5.0.M1 distribution 
-                and is also available from the Spring Milestones Maven Repository at <code>http://maven.springframework.org/milestone</code> under the group id 
+                and is also available from the Spring Milestones Maven Repository at <code>https://maven.springframework.org/milestone</code> under the group id 
                 <code>org.springframework.flex.roo.addon</code> and artifact id <code>org.springframework.flex.roo.addon</code>.
             </para>
             <para>
-                First, ensure that you have Spring Roo 1.1.0.M1 set up correctly by following the <ulink url="http://static.springsource.org/spring-roo/reference/html-single/index.html#intro-installation">steps found here</ulink>.
+                First, ensure that you have Spring Roo 1.1.0.M1 set up correctly by following the <ulink url="https://docs.spring.io/spring-roo/reference/html-single/index.html#intro-installation">steps found here</ulink>.
             </para>
             <para>
-                If you've not already done so, download the Spring BlazeDS Integration 1.5.0.M1 <ulink url="http://www.springsource.com/download/community?project=Spring%20BlazeDS%20Integration">project distribution</ulink>.
+                If you've not already done so, download the Spring BlazeDS Integration 1.5.0.M1 <ulink url="https://www.springsource.com/download/community?project=Spring%20BlazeDS%20Integration">project distribution</ulink>.
             </para>
             <para>
                 Once you have a working Spring Roo installation, you can install the Flex Addon by simply copying it from <code>{spring_blazeds_dist}/org.springframework.flex.roo.addon-1.0.0.M1.jar</code> into the 

--- a/docbkx/index.xml
+++ b/docbkx/index.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN" "http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
+<!DOCTYPE book PUBLIC "-//OASIS//DTD DocBook XML V4.4//EN" "https://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd">
 <book xmlns:xi="http://www.w3.org/2001/XInclude">
 
     <bookinfo>

--- a/org.springframework.flex.roo.addon/pom.xml
+++ b/org.springframework.flex.roo.addon/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.flex.roo.addon</groupId>
 	<artifactId>org.springframework.flex.roo.addon</artifactId>
@@ -31,32 +31,32 @@
 		<repository>
 			<id>com.springsource.repository.bundles.release</id>
 			<name>SpringSource Enterprise Bundle Repository - SpringSource Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/release</url>
+			<url>https://repository.springsource.com/maven/bundles/release</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.external</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Releases</name>
-			<url>http://repository.springsource.com/maven/bundles/external</url>
+			<url>https://repository.springsource.com/maven/bundles/external</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.milestone</id>
 			<name>SpringSource Enterprise Bundle Repository - External Bundle Milestones</name>
-			<url>http://repository.springsource.com/maven/bundles/milestone</url>
+			<url>https://repository.springsource.com/maven/bundles/milestone</url>
 		</repository>
 		<repository>
 			<id>com.springsource.repository.bundles.snapshot</id>
 			<name>SpringSource Enterprise Bundle Repository - Nightly Snapshots</name>
-			<url> http://repository.springsource.com/maven/bundles/snapshot</url>
+			<url> https://repository.springsource.com/maven/bundles/snapshot</url>
 		</repository>
 		<repository>
 			<id>maven.springframework.org.milestone</id>
 			<name>Spring Framework Maven Repository - Milestone Releases</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>maven.springframework.org.snapshot</id>
 			<name>Spring Framework Maven Repository - Nightly Snapshots</name>
-			<url>http://maven.springframework.org/milestone</url>
+			<url>https://maven.springframework.org/milestone</url>
 		</repository>
 		<repository>
 			<id>metaas-repo</id>

--- a/org.springframework.flex.roo.addon/src/main/assembly/assembly.xml
+++ b/org.springframework.flex.roo.addon/src/main/assembly/assembly.xml
@@ -2,7 +2,7 @@
 <assembly
 	xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 https://maven.apache.org/xsd/assembly-1.1.0.xsd">
 	<formats>
 		<format>zip</format>
 	</formats>

--- a/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/flex-config.xml
+++ b/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/flex-config.xml
@@ -4,9 +4,9 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		https://www.springframework.org/schema/beans/spring-beans-3.0.xsd
 		http://www.springframework.org/schema/flex 
-		http://www.springframework.org/schema/flex/spring-flex-1.5.xsd">
+		https://www.springframework.org/schema/flex/spring-flex-1.5.xsd">
   	
 	<flex:message-broker mapping-order="1">
 		<flex:mapping pattern="/messagebroker/*"/>

--- a/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/urlrewrite-template.xml
+++ b/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/urlrewrite-template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 3.0//EN" "http://tuckey.org/res/dtds/urlrewrite3.0.dtd">
+<!DOCTYPE urlrewrite PUBLIC "-//tuckey.org//DTD UrlRewrite 3.0//EN" "https://tuckey.org/res/dtds/urlrewrite3.0.dtd">
 
 <urlrewrite default-match-type="wildcard">
 	<rule>

--- a/org.springframework.flex.roo.annotations/pom.xml
+++ b/org.springframework.flex.roo.annotations/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.flex.roo.addon</groupId>
 	<artifactId>org.springframework.flex.roo.annotations</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.springframework.flex.roo.addon</groupId>
     <artifactId>org.springframework.flex.roo.root</artifactId>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://maven.badgers-in-foil.co.uk/maven2/ (403) with 1 occurrences could not be migrated:  
   ([https](https://maven.badgers-in-foil.co.uk/maven2/) result AnnotatedConnectException).
* http://spring-roo-repository.springsource.org/release (404) with 1 occurrences could not be migrated:  
   ([https](https://spring-roo-repository.springsource.org/release) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://static.springsource.org/spring-roo/reference/html-single/index.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-roo/reference/html-single/index.html ([https](https://static.springsource.org/spring-roo/reference/html-single/index.html) result 404).
* http://repository.springsource.com/maven/bundles/external (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/external ([https](https://repository.springsource.com/maven/bundles/external) result 404).
* http://repository.springsource.com/maven/bundles/milestone (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/milestone ([https](https://repository.springsource.com/maven/bundles/milestone) result 404).
* http://repository.springsource.com/maven/bundles/release (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/release ([https](https://repository.springsource.com/maven/bundles/release) result 404).
* http://repository.springsource.com/maven/bundles/snapshot (404) with 1 occurrences migrated to:  
  https://repository.springsource.com/maven/bundles/snapshot ([https](https://repository.springsource.com/maven/bundles/snapshot) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org/xsd/assembly-1.1.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/assembly-1.1.0.xsd ([https](https://maven.apache.org/xsd/assembly-1.1.0.xsd) result 200).
* http://tuckey.org/res/dtds/urlrewrite3.0.dtd with 1 occurrences migrated to:  
  https://tuckey.org/res/dtds/urlrewrite3.0.dtd ([https](https://tuckey.org/res/dtds/urlrewrite3.0.dtd) result 200).
* http://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd with 1 occurrences migrated to:  
  https://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd ([https](https://www.oasis-open.org/docbook/xml/4.4/docbookx.dtd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-3.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-3.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-3.0.xsd) result 200).
* http://www.springframework.org/schema/flex/spring-flex-1.5.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/flex/spring-flex-1.5.xsd ([https](https://www.springframework.org/schema/flex/spring-flex-1.5.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 3 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).
* http://www.springsource.org/roo with 3 occurrences migrated to:  
  https://www.springsource.org/roo ([https](https://www.springsource.org/roo) result 301).
* http://maven.springframework.org/milestone with 3 occurrences migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).
* http://www.springsource.com/download/community?project=Spring%20BlazeDS%20Integration with 1 occurrences migrated to:  
  https://www.springsource.com/download/community?project=Spring%20BlazeDS%20Integration ([https](https://www.springsource.com/download/community?project=Spring%20BlazeDS%20Integration) result 302).

# Ignored
These URLs were intentionally ignored.

* http://jakarta.apache.org/log4j/ with 1 occurrences
* http://localhost:8080/ with 1 occurrences
* http://localhost:8080/rootunes/rootunes_scaffold.html with 2 occurrences
* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 with 2 occurrences
* http://www.adobe.com/2006/flex-config with 1 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/flex with 2 occurrences
* http://www.w3.org/2001/XInclude with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 5 occurrences