### PR TITLE
URL Cleanup

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 FLEX ADDON FOR SPRING ROO CHANGELOG
 =========================
-http://www.springsource.org/spring-flex
+https://www.springsource.org/spring-flex
 
 Changes in Flex Addon for Spring Roo 1.0.0.M1 (06.30.2010)
 _________________________________________

--- a/docbkx/resources/xsl/highlight-fo.xsl
+++ b/docbkx/resources/xsl/highlight-fo.xsl
@@ -5,7 +5,7 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/docbkx/resources/xsl/highlight.xsl
+++ b/docbkx/resources/xsl/highlight.xsl
@@ -3,7 +3,7 @@
     Simple highlighter for HTML output. Follows the Eclipse color scheme.
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"
                 version='1.0'>
 

--- a/docbkx/resources/xsl/html.xsl
+++ b/docbkx/resources/xsl/html.xsl
@@ -5,7 +5,7 @@
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:xslthl="http://xslthl.sf.net"
+                xmlns:xslthl="http://xslthl.sourceforge.net/"
                 exclude-result-prefixes="xslthl"                
                 version="1.0">
                 
@@ -93,11 +93,11 @@
     <!-- let's have a Spring and I21 banner across the top of each page -->
     <xsl:template name="user.header.navigation">
         <div style="background-color:white;border:none;height:73px;border:1px solid black;">
-            <a style="border:none;" href="http://www.springframework.org/osgi/"
+            <a style="border:none;" href="https://www.springframework.org/osgi/"
                title="The Spring Framework - Spring Data">
                 <img style="border:none;" src="images/xdev-spring_logo.jpg"/>
             </a>
-            <a style="border:none;" href="http://www.SpringSource.com/" title="SpringSource - Spring from the Source">
+            <a style="border:none;" href="https://www.SpringSource.com/" title="SpringSource - Spring from the Source">
                 <img style="border:none;position:absolute;padding-top:5px;right:42px;" src="images/s2-banner-rhs.png"/>
             </a>
         </div>

--- a/docbkx/resources/xsl/html_chunk.xsl
+++ b/docbkx/resources/xsl/html_chunk.xsl
@@ -86,11 +86,11 @@
     <!-- let's have a Spring and I21 banner across the top of each page -->
     <xsl:template name="user.header.navigation">
         <div style="background-color:white;border:none;height:73px;border:1px solid black;">
-            <a style="border:none;" href="http://www.springframework.org/osgi/"
+            <a style="border:none;" href="https://www.springframework.org/osgi/"
                title="The Spring Framework - Spring Data">
                 <img style="border:none;" src="images/xdev-spring_logo.jpg"/>
             </a>
-            <a style="border:none;" href="http://www.SpringSource.com/" title="SpringSource - Spring from the Source">
+            <a style="border:none;" href="https://www.SpringSource.com/" title="SpringSource - Spring from the Source">
                 <img style="border:none;position:absolute;padding-top:5px;right:42px;" src="images/s2-banner-rhs.png"/>
             </a>
         </div>
@@ -200,7 +200,7 @@
                                 </td>
                                 <td width="20%" align="center">
                                     <span style="color:white;font-size:90%;">
-                                        <a href="http://www.SpringSource.com/"
+                                        <a href="https://www.SpringSource.com/"
                                            title="SpringSource - Spring from the Source">Sponsored by SpringSource
                                         </a>
                                     </span>

--- a/notice.txt
+++ b/notice.txt
@@ -4,13 +4,13 @@
    ======================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternately, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexOperationsImpl.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexOperationsImpl.java
@@ -401,12 +401,12 @@ public class FlexOperationsImpl implements FlexOperations {
     private void configureFlexBuild() {
         ProjectMetadata projectMetadata = (ProjectMetadata) this.metadataService.get(ProjectMetadata.getProjectIdentifier());
 
-        Repository externalRepository = new Repository("spring-external", "Spring External Repository", "http://maven.springframework.org/external");
+        Repository externalRepository = new Repository("spring-external", "Spring External Repository", "https://maven.springframework.org/external");
         if (!projectMetadata.isRepositoryRegistered(externalRepository)) {
             this.projectOperations.addRepository(externalRepository);
         }
 
-        Repository flexRepository = new Repository("flex", "Sonatype Flex Repo", "http://repository.sonatype.org/content/groups/flexgroup");
+        Repository flexRepository = new Repository("flex", "Sonatype Flex Repo", "https://repository.sonatype.org/content/groups/flexgroup");
         if (!projectMetadata.isRepositoryRegistered(flexRepository)) {
             this.projectOperations.addRepository(flexRepository);
         }

--- a/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/appname_scaffold_html.st
+++ b/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/appname_scaffold_html.st
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!-- saved from url=(0014)about:internet -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">	
     <!-- 
@@ -8,7 +8,7 @@
     for building rich Internet applications that get delivered via the
     Flash Player or to desktops via Adobe AIR. 
     
-    Learn more about Flex at http://flex.org 
+    Learn more about Flex at https://flex.org 
     // -->
     <head>
         <title>$projectName$</title>         
@@ -68,7 +68,7 @@
 			</p>
 			<script type="text/javascript"> 
 				var pageHost = ((document.location.protocol == "https:") ? "https://" :	"http://"); 
-				document.write("<a href='http://www.adobe.com/go/getflashplayer'><img src='" 
+				document.write("<a href='https://www.adobe.com/go/getflashplayer'><img src='" 
 								+ pageHost + "www.adobe.com/images/shared/download_buttons/get_flash_player.gif' alt='Get Adobe Flash player' /></a>" ); 
 			</script> 
         </div>
@@ -93,8 +93,8 @@
                 		10.0.0 or greater is not installed.
                 	</p>
                 <!--<![endif]-->
-                    <a href="http://www.adobe.com/go/getflashplayer">
-                        <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash Player" />
+                    <a href="https://www.adobe.com/go/getflashplayer">
+                        <img src="https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash Player" />
                     </a>
                 <!--[if !IE]>-->
                 </object>

--- a/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/flashbuilder/html-template/index.template.html
+++ b/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/flashbuilder/html-template/index.template.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <!-- saved from url=(0014)about:internet -->
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">	
     <!-- 
@@ -8,7 +8,7 @@
     for building rich Internet applications that get delivered via the
     Flash Player or to desktops via Adobe AIR. 
     
-    Learn more about Flex at http://flex.org 
+    Learn more about Flex at https://flex.org 
     // -->
     <head>
         <title>${title}</title>         
@@ -68,7 +68,7 @@
 			</p>
 			<script type="text/javascript"> 
 				var pageHost = ((document.location.protocol == "https:") ? "https://" :	"http://"); 
-				document.write("<a href='http://www.adobe.com/go/getflashplayer'><img src='" 
+				document.write("<a href='https://www.adobe.com/go/getflashplayer'><img src='" 
 								+ pageHost + "www.adobe.com/images/shared/download_buttons/get_flash_player.gif' alt='Get Adobe Flash player' /></a>" ); 
 			</script> 
         </div>
@@ -93,8 +93,8 @@
                 		${version_major}.${version_minor}.${version_revision} or greater is not installed.
                 	</p>
                 <!--<![endif]-->
-                    <a href="http://www.adobe.com/go/getflashplayer">
-                        <img src="http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash Player" />
+                    <a href="https://www.adobe.com/go/getflashplayer">
+                        <img src="https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif" alt="Get Adobe Flash Player" />
                     </a>
                 <!--[if !IE]>-->
                 </object>

--- a/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/flashbuilder/html-template/swfobject.js
+++ b/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/flashbuilder/html-template/swfobject.js
@@ -1,5 +1,5 @@
-/*!	SWFObject v2.2 <http://code.google.com/p/swfobject/> 
-	is released under the MIT License <http://www.opensource.org/licenses/mit-license.php> 
+/*!	SWFObject v2.2 <https://code.google.com/p/swfobject/> 
+	is released under the MIT License <https://www.opensource.org/licenses/mit-license.php> 
 */
 
 var swfobject = function() {
@@ -42,7 +42,7 @@ var swfobject = function() {
 			windows = p ? /win/.test(p) : /win/.test(u),
 			mac = p ? /mac/.test(p) : /mac/.test(u),
 			webkit = /webkit/.test(u) ? parseFloat(u.replace(/^.*webkit\/(\d+(\.\d+)?).*$/, "$1")) : false, // returns either the webkit version or false if not webkit
-			ie = !+"\v1", // feature detection based on Andrea Giammarchi's solution: http://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html
+			ie = !+"\v1", // feature detection based on Andrea Giammarchi's solution: https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html
 			playerVersion = [0,0,0],
 			d = null;
 		if (typeof nav.plugins != UNDEF && typeof nav.plugins[SHOCKWAVE_FLASH] == OBJECT) {
@@ -146,7 +146,7 @@ var swfobject = function() {
 	}
 	
 	/* Cross-browser onload
-		- Based on James Edwards' solution: http://brothercake.com/site/resources/scripts/onload/
+		- Based on James Edwards' solution: https://brothercake.com/site/resources/scripts/onload/
 		- Will fire an event as soon as a web page including all of its assets are loaded 
 	 */
 	function addLoadEvent(fn) {
@@ -307,7 +307,7 @@ var swfobject = function() {
 	}
 	
 	/* Show the Adobe Express Install dialog
-		- Reference: http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75
+		- Reference: https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75
 	*/
 	function showExpressInstall(att, par, replaceElemIdStr, callbackFn) {
 		isExpressInstallActive = true;
@@ -537,7 +537,7 @@ var swfobject = function() {
 	}
 	
 	/* Cross-browser dynamic CSS creation
-		- Based on Bobby van der Sluis' solution: http://www.bobbyvandersluis.com/articles/dynamicCSS.php
+		- Based on Bobby van der Sluis' solution: https://www.bobbyvandersluis.com/articles/dynamicCSS.php
 	*/	
 	function createCSS(sel, decl, media, newStyle) {
 		if (ua.ie && ua.mac) { return; }
@@ -621,7 +621,7 @@ var swfobject = function() {
 	
 	return {
 		/* Public API
-			- Reference: http://code.google.com/p/swfobject/wiki/documentation
+			- Reference: https://code.google.com/p/swfobject/wiki/documentation
 		*/ 
 		registerObject: function(objectIdStr, swfVersionStr, xiSwfUrlStr, callbackFn) {
 			if (ua.w3 && objectIdStr && swfVersionStr) {

--- a/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/htmlwrapper/swfobject.js
+++ b/org.springframework.flex.roo.addon/src/main/resources/org/springframework/flex/roo/addon/htmlwrapper/swfobject.js
@@ -1,5 +1,5 @@
-/*!	SWFObject v2.2 <http://code.google.com/p/swfobject/> 
-	is released under the MIT License <http://www.opensource.org/licenses/mit-license.php> 
+/*!	SWFObject v2.2 <https://code.google.com/p/swfobject/> 
+	is released under the MIT License <https://www.opensource.org/licenses/mit-license.php> 
 */
 
 var swfobject = function() {
@@ -42,7 +42,7 @@ var swfobject = function() {
 			windows = p ? /win/.test(p) : /win/.test(u),
 			mac = p ? /mac/.test(p) : /mac/.test(u),
 			webkit = /webkit/.test(u) ? parseFloat(u.replace(/^.*webkit\/(\d+(\.\d+)?).*$/, "$1")) : false, // returns either the webkit version or false if not webkit
-			ie = !+"\v1", // feature detection based on Andrea Giammarchi's solution: http://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html
+			ie = !+"\v1", // feature detection based on Andrea Giammarchi's solution: https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html
 			playerVersion = [0,0,0],
 			d = null;
 		if (typeof nav.plugins != UNDEF && typeof nav.plugins[SHOCKWAVE_FLASH] == OBJECT) {
@@ -146,7 +146,7 @@ var swfobject = function() {
 	}
 	
 	/* Cross-browser onload
-		- Based on James Edwards' solution: http://brothercake.com/site/resources/scripts/onload/
+		- Based on James Edwards' solution: https://brothercake.com/site/resources/scripts/onload/
 		- Will fire an event as soon as a web page including all of its assets are loaded 
 	 */
 	function addLoadEvent(fn) {
@@ -307,7 +307,7 @@ var swfobject = function() {
 	}
 	
 	/* Show the Adobe Express Install dialog
-		- Reference: http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75
+		- Reference: https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75
 	*/
 	function showExpressInstall(att, par, replaceElemIdStr, callbackFn) {
 		isExpressInstallActive = true;
@@ -537,7 +537,7 @@ var swfobject = function() {
 	}
 	
 	/* Cross-browser dynamic CSS creation
-		- Based on Bobby van der Sluis' solution: http://www.bobbyvandersluis.com/articles/dynamicCSS.php
+		- Based on Bobby van der Sluis' solution: https://www.bobbyvandersluis.com/articles/dynamicCSS.php
 	*/	
 	function createCSS(sel, decl, media, newStyle) {
 		if (ua.ie && ua.mac) { return; }
@@ -621,7 +621,7 @@ var swfobject = function() {
 	
 	return {
 		/* Public API
-			- Reference: http://code.google.com/p/swfobject/wiki/documentation
+			- Reference: https://code.google.com/p/swfobject/wiki/documentation
 		*/ 
 		registerObject: function(objectIdStr, swfVersionStr, xiSwfUrlStr, callbackFn) {
 			if (ua.w3 && objectIdStr && swfVersionStr) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 FLEX ADDON FOR SPRING ROO 1.0.0.M2 (? 2011)
 ----------------------------------
-http://www.springsource.org/spring-flex
+https://www.springsource.org/spring-flex
 
 1. INTRODUCTION
 ---------------


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://javascript.nwbox.com/IEContentLoaded/ (200) with 2 occurrences could not be migrated:  
   ([https](https://javascript.nwbox.com/IEContentLoaded/) result SSLHandshakeException).
* [ ] http://xslthl.sf.net (301) with 3 occurrences could not be migrated:  
   ([https](https://xslthl.sf.net) result AnnotatedConnectException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://flex.org (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://flex.org ([https](https://flex.org) result ConnectTimeoutException).
* [ ] http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd (ReadTimeoutException) with 2 occurrences migrated to:  
  https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd ([https](https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd) result SSLException).
* [ ] http://maven.springframework.org/external (404) with 1 occurrences migrated to:  
  https://maven.springframework.org/external ([https](https://maven.springframework.org/external) result 404).
* [ ] http://www.bobbyvandersluis.com/articles/dynamicCSS.php (301) with 2 occurrences migrated to:  
  https://www.bobbyvandersluis.com/articles/dynamicCSS.php ([https](https://www.bobbyvandersluis.com/articles/dynamicCSS.php) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://brothercake.com/site/resources/scripts/onload/ with 2 occurrences migrated to:  
  https://brothercake.com/site/resources/scripts/onload/ ([https](https://brothercake.com/site/resources/scripts/onload/) result 200).
* [ ] http://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html with 2 occurrences migrated to:  
  https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html ([https](https://webreflection.blogspot.com/2009/01/32-bytes-to-know-if-your-browser-is-ie.html) result 200).
* [ ] http://www.adobe.com/images/shared/download_buttons/get_flash_player.gif with 2 occurrences migrated to:  
  https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif ([https](https://www.adobe.com/images/shared/download_buttons/get_flash_player.gif) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.springframework.org/osgi/ with 2 occurrences migrated to:  
  https://www.springframework.org/osgi/ ([https](https://www.springframework.org/osgi/) result 200).
* [ ] http://code.google.com/p/swfobject/ with 2 occurrences migrated to:  
  https://code.google.com/p/swfobject/ ([https](https://code.google.com/p/swfobject/) result 301).
* [ ] http://code.google.com/p/swfobject/wiki/documentation with 2 occurrences migrated to:  
  https://code.google.com/p/swfobject/wiki/documentation ([https](https://code.google.com/p/swfobject/wiki/documentation) result 301).
* [ ] http://www.SpringSource.com/ with 3 occurrences migrated to:  
  https://www.SpringSource.com/ ([https](https://www.SpringSource.com/) result 301).
* [ ] http://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75 with 2 occurrences migrated to:  
  https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75 ([https](https://www.adobe.com/cfusion/knowledgebase/index.cfm?id=6a253b75) result 301).
* [ ] http://www.adobe.com/go/getflashplayer with 4 occurrences migrated to:  
  https://www.adobe.com/go/getflashplayer ([https](https://www.adobe.com/go/getflashplayer) result 301).
* [ ] http://www.opensource.org/licenses/mit-license.php with 2 occurrences migrated to:  
  https://www.opensource.org/licenses/mit-license.php ([https](https://www.opensource.org/licenses/mit-license.php) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.org/spring-flex with 2 occurrences migrated to:  
  https://www.springsource.org/spring-flex ([https](https://www.springsource.org/spring-flex) result 301).
* [ ] http://repository.sonatype.org/content/groups/flexgroup with 1 occurrences migrated to:  
  https://repository.sonatype.org/content/groups/flexgroup ([https](https://repository.sonatype.org/content/groups/flexgroup) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/ with 2 occurrences
* http://ns.adobe.com/mxml/2009 with 3 occurrences
* http://www.w3.org/1999/XSL/Format with 5 occurrences
* http://www.w3.org/1999/XSL/Transform with 5 occurrences
* http://www.w3.org/1999/xhtml with 2 occurrences