### PR TITLE
URL Cleanup

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexCommands.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexCommands.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexOperations.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexOperations.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexOperationsImpl.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexOperationsImpl.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexProjectListener.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexProjectListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexScaffoldAnnotationValues.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexScaffoldAnnotationValues.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexScaffoldMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexScaffoldMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexScaffoldMetadataProvider.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/FlexScaffoldMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/RooFlexScaffold.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/RooFlexScaffold.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASMutablePhysicalTypeMetadataProvider.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASMutablePhysicalTypeMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeCategory.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeCategory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeIdentifier.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeIdentifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeIdentifierNamingUtils.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeIdentifierNamingUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeMetadataProvider.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/ASPhysicalTypeMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserClassMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserClassMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserMetadataProvider.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserMutableClassOrInterfaceTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserMutableClassOrInterfaceTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserUtils.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/CompilationUnitServices.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/CompilationUnitServices.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserConstructorMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserConstructorMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserFieldMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserFieldMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserMetaTagMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserMetaTagMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserMethodMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/as3parser/details/As3ParserMethodMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASClassOrInterfaceTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASClassOrInterfaceTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASConstructorMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASConstructorMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASFieldMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASFieldMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASIdentifiableMember.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASIdentifiableMember.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASInvocableMemberMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASInvocableMemberMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASMemberHoldingTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASMemberHoldingTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASMethodMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASMethodMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASMutableClassOrInterfaceTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/ASMutableClassOrInterfaceTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/AbstractASFieldMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/AbstractASFieldMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/AbstractInvocableMemberMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/AbstractInvocableMemberMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASClassOrInterfaceTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASClassOrInterfaceTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASConstructorMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASConstructorMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASFieldMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASFieldMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASMethodMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASMethodMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASPhysicalTypeDetails.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASPhysicalTypeDetails.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASPhysicalTypeMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/DefaultASPhysicalTypeMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/ASMetaTagMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/ASMetaTagMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/AbstractMetaTagAttributeValue.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/AbstractMetaTagAttributeValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/BooleanAttributeValue.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/BooleanAttributeValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/DefaultASMetaTagMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/DefaultASMetaTagMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/IntegerAttributeValue.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/IntegerAttributeValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/MetaTagAttributeValue.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/MetaTagAttributeValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/StringAttributeValue.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/classpath/details/metatag/StringAttributeValue.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ASDataType.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ASDataType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ASTypeVisibility.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ASTypeVisibility.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptMappingUtils.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptMappingUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptPackage.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptPackage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptSymbolName.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptSymbolName.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptType.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/as/model/ActionScriptType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/entity/ActionScriptEntityMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/entity/ActionScriptEntityMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/entity/ActionScriptEntityMetadataProvider.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/entity/ActionScriptEntityMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/entity/TypeMapping.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/entity/TypeMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/mojos/FlexMojosPathResolver.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/mojos/FlexMojosPathResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/mojos/FlexPath.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/mojos/FlexPath.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/mojos/FlexPathResolver.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/mojos/FlexPathResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/ui/FlexUIMetadata.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/ui/FlexUIMetadata.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/ui/FlexUIMetadataProvider.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/ui/FlexUIMetadataProvider.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/ui/MxmlRoundTripUtils.java
+++ b/org.springframework.flex.roo.addon/src/main/java/org/springframework/flex/roo/addon/ui/MxmlRoundTripUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserClassMetadataMutableTypeDetailsTests.java
+++ b/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserClassMetadataMutableTypeDetailsTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserClassMetadataValidParsingTests.java
+++ b/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserClassMetadataValidParsingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserMetadataProviderTests.java
+++ b/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/as/classpath/as3parser/As3ParserMetadataProviderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/ui/FormTemplateTests.java
+++ b/org.springframework.flex.roo.addon/src/test/java/org/springframework/flex/roo/addon/ui/FormTemplateTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/org.springframework.flex.roo.annotations/src/main/java/org/springframework/flex/roo/addon/RooFlexScaffold.java
+++ b/org.springframework.flex.roo.annotations/src/main/java/org/springframework/flex/roo/addon/RooFlexScaffold.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  * 
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *   https://www.apache.org/licenses/LICENSE-2.0
  * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 68 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).